### PR TITLE
Fix usage of deprecated rU file mode

### DIFF
--- a/hm_gerber_ex/common.py
+++ b/hm_gerber_ex/common.py
@@ -16,7 +16,7 @@ import hm_gerber_ex.excellon
 
 
 def read(filename, format=None):
-    with open(filename, 'rU') as f:
+    with open(filename, 'r') as f:
         data = f.read()
     return loads(data, filename, format=format)
 

--- a/hm_gerber_tool/common.py
+++ b/hm_gerber_tool/common.py
@@ -36,7 +36,7 @@ def read(filename):
         CncFile object representing the file, either GerberFile, ExcellonFile,
         or IPCNetlist. Returns None if file is not of the proper type.
     """
-    with open(filename, 'rU') as f:
+    with open(filename, 'r') as f:
         try:
             data = f.read()
             return loads(data, filename)

--- a/hm_gerber_tool/excellon.py
+++ b/hm_gerber_tool/excellon.py
@@ -53,7 +53,7 @@ def read(filename):
 
     """
     # File object should use settings from source file by default.
-    with open(filename, 'rU') as f:
+    with open(filename, 'r') as f:
         data = f.read()
     settings = FileSettings(**detect_excellon_format(data))
     return ExcellonParser(settings).parse(filename)
@@ -433,7 +433,7 @@ class ExcellonParser(object):
         return len(self.hits)
 
     def parse(self, filename):
-        with open(filename, 'rU') as f:
+        with open(filename, 'r') as f:
             data = f.read()
         return self.parse_raw(data, filename)
 
@@ -832,7 +832,7 @@ def detect_excellon_format(data=None, filename=None):
     if data is None and filename is None:
         raise ValueError('Either data or filename arguments must be provided')
     if data is None:
-        with open(filename, 'rU') as f:
+        with open(filename, 'r') as f:
             data = f.read()
 
     # Check for obvious clues:

--- a/hm_gerber_tool/ipc356.py
+++ b/hm_gerber_tool/ipc356.py
@@ -163,7 +163,7 @@ class IPCNetlistParser(object):
         return FileSettings(units=self.units, angle_units=self.angle_units)
 
     def parse(self, filename):
-        with open(filename, 'rU') as f:
+        with open(filename, 'r') as f:
             data = f.read()
         return self.parse_raw(data, filename)
 

--- a/hm_gerber_tool/rs274x.py
+++ b/hm_gerber_tool/rs274x.py
@@ -260,7 +260,7 @@ class GerberParser(object):
 
     def parse(self, filename):
         self.filename = filename
-        with open(filename, "rU") as fp:
+        with open(filename, "r") as fp:
             data = fp.read()
         return self.parse_raw(data, filename)
 


### PR DESCRIPTION
The `rU` file mode is deprecated, it does not have any effect since Python 3.0 and causes errors while opening the file at newer Python versions (happening with 3.11.6 for me).

https://docs.python.org/3/library/functions.html#open

Closes #11 