### PR TITLE
Make main.py file executable with system Python 3 interpreter

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # The MIT License (MIT)
 
 # Copyright 2021,2022 HalfMarble LLC


### PR DESCRIPTION
A simple change to allow running `./main.py`.